### PR TITLE
Adding utility token functions #54

### DIFF
--- a/dl/authClient.py
+++ b/dl/authClient.py
@@ -59,7 +59,7 @@ except ImportError:
 #    from Util import def_token
 #else:                                           # use distribution copy
 #    from dl.Util import def_token
-from dl.Util import def_token
+from dl.Util import def_token, split_auth_token
 
 is_py3 = sys.version_info.major == 3
 
@@ -156,7 +156,7 @@ def whoAmI():
     user = 'anonymous'
     try:
         token = def_token(None)
-        user, uid, gid, hash = token.strip().split('.', 3)
+        user, uid, gid, hash = split_auth_token(token.strip())
     except:
         return 'anonymous'
     else:
@@ -173,7 +173,7 @@ def isAlive(svc_url=DEF_SERVICE_URL):
 
 def isValidToken(token):
     try:
-        user, uid, gid, hash = token.strip().split('.', 3)
+        user, uid, gid, hash = split_auth_token(token.strip())
     except Exception:
         return False
 
@@ -370,7 +370,7 @@ class authClient(object):
         user = 'anonymous'
         try:
             token = def_token(None)
-            user, uid, gid, hash = token.strip().split('.', 3)
+            user, uid, gid, hash = split_auth_token(token.strip())
         except:
             return 'anonymous'
         else:
@@ -687,7 +687,7 @@ class authClient(object):
             print("logout: logged in = " + self.isTokenLoggedIn(token))
 
         try:
-            user, uid, gid, hash = token.strip().split('.', 3)
+            user, uid, gid, hash = split_auth_token(token.strip())
         except Exception:
             raise dlAuthError('Error: Invalid user token')
 
@@ -764,7 +764,7 @@ class authClient(object):
         # Reset the auth_token to the one passed in by the service call.
         self.auth_token = token
 
-        user, uid, gid, hash = self.auth_token.strip().split('.', 3)
+        user, uid, gid, hash = split_auth_token(self.auth_token.strip())
         if user != 'root' and user != username:
             raise Exception("Error: Invalid user or non-root token")
 
@@ -1044,7 +1044,7 @@ class authClient(object):
         '''Get default tracking headers.
         '''
         tok = def_token(token)
-        user, uid, gid, hash = tok.strip().split('.', 3)
+        user, uid, gid, hash = split_auth_token(tok.strip())
         hdrs = {'Content-Type': 'text/ascii',
                 'X-DL-ClientVersion': __version__,
                 'X-DL-OriginIP': self.hostip,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,10 +22,10 @@ import dl.Util as util
 ANON_TOKEN = "anonymous.0.0.anon_access"
 DEMO_TOKEN = "dldemo.99999.99999.demo_access"
 TEST_TOKEN = "dltest.99998.99998.test_access"
-DEMO00_OK_TOKEN = "demo00.1018.1018.$1$fdqe8g1I$jN1F2CZ8MhdbZNnuG9jAB/"
-DEMO00_KO_TOKEN = "demo00.1018.1018.$2$fdqe8g1I$jN1F2CZ8MhdbZNnuG9jAB/"
-DEMO00_TOO_SHORT = "demo00.1018.1018.$1$fdqe8g1I$jN1F2CZ8Mhdb"
-SOME_USER = "some_user.3195.159.$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."
+UNITTEST_OK_TOKEN = "unittest.666.666.$1$fdqasldur927JL97asldfj9279172B/"
+UNITTEST_KO_TOKEN = "unittest.666.666.$2$fdqasldur927JL97asldfj9279172B/"
+UNITTEST_TOO_SHORT = "unittest.666.666.$1$fdqasldur927JL97asldf"
+SOME_USER = "some_user.3199.159.$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."
 
 
 @pytest.mark.parametrize(
@@ -35,9 +35,9 @@ SOME_USER = "some_user.3195.159.$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."
        (ANON_TOKEN, True),
        (DEMO_TOKEN, True),
        (TEST_TOKEN, True),
-       (DEMO00_OK_TOKEN, True),
-       (DEMO00_KO_TOKEN, False),
-       (DEMO00_TOO_SHORT, False),
+       (UNITTEST_OK_TOKEN, True),
+       (UNITTEST_KO_TOKEN, False),
+       (UNITTEST_TOO_SHORT, False),
 
    ]
 )
@@ -52,8 +52,8 @@ def test_is_auth_token(token, expected):
         (ANON_TOKEN, ["anonymous", "0", "0", "anon_access"]),
         (DEMO_TOKEN, ["dldemo", "99999", "99999", "demo_access"]),
         (TEST_TOKEN, ["dltest", "99998", "99998", "test_access"]),
-        (DEMO00_OK_TOKEN, ["demo00", "1018", "1018", "$1$fdqe8g1I$jN1F2CZ8MhdbZNnuG9jAB/"]),
-        (SOME_USER, ["some_user", "3195", "159", "$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."])
+        (UNITTEST_OK_TOKEN, ["unittest", "666", "666", "$1$fdqasldur927JL97asldfj9279172B/"]),
+        (SOME_USER, ["some_user", "3199", "159", "$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."])
     ]
 )
 def test_split_auth_token_parts(token, expected):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,62 @@
+"""
+    test_util.py - test functionality in dl/Util.py
+    To run the test everything simply do:
+        pytest tests/test_util.py
+  To test individual test methods verbose (-v):
+    pytest tests/test_util.py::test_is_auth_token -v
+    pytest tests/test_util.py::test_split_auth_token_parts -v
+"""
+
+__authors__ = 'Igor Sola<igor.suarez-sola@noirlab.edu>'
+__version__ = '20221011'  # yyyymmdd
+import os
+import sys
+import pytest
+
+# position the script relative to the code
+ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(ROOT_PATH, '..'))
+import dl.Util as util
+
+
+ANON_TOKEN = "anonymous.0.0.anon_access"
+DEMO_TOKEN = "dldemo.99999.99999.demo_access"
+TEST_TOKEN = "dltest.99998.99998.test_access"
+DEMO00_OK_TOKEN = "demo00.1018.1018.$1$fdqe8g1I$jN1F2CZ8MhdbZNnuG9jAB/"
+DEMO00_KO_TOKEN = "demo00.1018.1018.$2$fdqe8g1I$jN1F2CZ8MhdbZNnuG9jAB/"
+DEMO00_TOO_SHORT = "demo00.1018.1018.$1$fdqe8g1I$jN1F2CZ8Mhdb"
+SOME_USER = "some_user.3195.159.$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+   [
+       ("", False),
+       (ANON_TOKEN, True),
+       (DEMO_TOKEN, True),
+       (TEST_TOKEN, True),
+       (DEMO00_OK_TOKEN, True),
+       (DEMO00_KO_TOKEN, False),
+       (DEMO00_TOO_SHORT, False),
+
+   ]
+)
+def test_is_auth_token(token, expected):
+    res = util.is_auth_token(token)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        (ANON_TOKEN, ["anonymous", "0", "0", "anon_access"]),
+        (DEMO_TOKEN, ["dldemo", "99999", "99999", "demo_access"]),
+        (TEST_TOKEN, ["dltest", "99998", "99998", "test_access"]),
+        (DEMO00_OK_TOKEN, ["demo00", "1018", "1018", "$1$fdqe8g1I$jN1F2CZ8MhdbZNnuG9jAB/"]),
+        (SOME_USER, ["some_user", "3195", "159", "$1$3xf8E6xf$RL9XLqIyFCRsTOISOBTuL."])
+    ]
+)
+def test_split_auth_token_parts(token, expected):
+    res = util.split_auth_token(token)
+    for a, b in zip(res, expected):
+        assert a == b


### PR DESCRIPTION
This commit is linked to issue #54

Three token manipulation functions have been added to the Util.py package namely:

.- "parse_auth_token: runs a regular expression on a string and returns a
                      regex Match object or nothing
.- split_auth_token: takes the Matched object and converts it into an
                     array
.- is_auth_token: returns True if parse_auth_token returns a match or
                  False otherwise

Added unit test tests/test_util.py to test split_auth_token and is_auth_token