### PR TITLE
Added step to upload package to PyPI in workflow

### DIFF
--- a/.github/workflows/datalab_pip.yml
+++ b/.github/workflows/datalab_pip.yml
@@ -5,7 +5,7 @@ on:
     branches: 
       - master
   release:
-    types: [ created ]
+    types: [ released ]
 
 jobs:
   build:

--- a/.github/workflows/datalab_pip.yml
+++ b/.github/workflows/datalab_pip.yml
@@ -38,6 +38,6 @@ jobs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      #run: twine upload dist/*
-      # test only
-      run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+      run: twine upload dist/*
+      ## test only
+      # run: twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*

--- a/.github/workflows/datalab_pip.yml
+++ b/.github/workflows/datalab_pip.yml
@@ -38,6 +38,11 @@ jobs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: twine upload dist/*
-      ## test only
-      # run: twine upload --verbose --repository-url https://test.pypi.org/legacy/ dist/*
+        # for testing purposes set the PYPI_REPO_URL to https://test.pypi.org/legacy/
+        PYPI_REPO_URL: ''
+      run: |
+        if [ -z "${{ env.PYPI_REPO_URL }}" ]; then
+          twine upload --verbose dist/*
+        else
+          twine upload --verbose --repository-url "${{ env.PYPI_REPO_URL }}" dist/*
+        fi


### PR DESCRIPTION
On Friday I made a mistake and pushed to master, 46ff5d77, a modified version of the workflow datalab_pip.yml, basically I added the last step that checks if it is a release, and if so uploads the packages to PyPi.

The push I did on Friday, was pointing to the test.pypi.org. This version simply is pointing to the "real" pypi.org.